### PR TITLE
docs: configuração da EC2 bia-dev na rule de infraestrutura

### DIFF
--- a/.kiro/rules/infraestrutura.md
+++ b/.kiro/rules/infraestrutura.md
@@ -68,6 +68,29 @@
 - **Porta:** 80/443
 - **Source:** 0.0.0.0/0 → Descrição: "acesso público HTTP/HTTPS"
 
+## EC2 de Desenvolvimento (bia-dev)
+
+### Configuração da Instância
+- **Nome (Tag Name):** `bia-dev`
+- **Tipo:** `t3.micro`
+- **AMI:** Amazon Linux 2023 (última versão disponível)
+- **Key Pair:** `bia-dev`
+- **Security Group:** `bia-dev`
+- **Região:** `us-east-1` (Virginia)
+- **Subnet:** zona A (`us-east-1a`)
+- **IP Público:** habilitado
+
+### User Data
+- **Script:** `scripts/user_data_ec2_zona_a.sh`
+- **O script instala:**
+  - Docker + Docker Compose v2.23.3
+  - Git, jq
+  - AWS CLI v2
+  - Node.js 21.x + npm
+  - Python 3.11 + uv (para MCP servers da AWS)
+  - Swap de 4GB (128M × 32)
+  - Adiciona `ec2-user` e `ssm-user` ao grupo `docker`
+
 ## Banco de Dados
 - **Aproveitamento:** Usar banco existente na infraestrutura
 - **Não criar:** Novos recursos RDS nos templates


### PR DESCRIPTION
## O que foi alterado

Adicionada seção **EC2 de Desenvolvimento (bia-dev)** na rule de infraestrutura, vinculando o script `scripts/user_data_ec2_zona_a.sh` com a definição completa da instância.

## Detalhes da configuração documentada

- Tipo: `t3.micro`
- AMI: Amazon Linux 2023 (última versão)
- Key Pair: `bia-dev`
- Security Group: `bia-dev`
- Subnet: zona A (`us-east-1a`)
- IP Público: habilitado
- User Data: `scripts/user_data_ec2_zona_a.sh`

## O que o script instala

- Docker + Docker Compose v2.23.3
- Git, jq, AWS CLI v2
- Node.js 21.x + npm
- Python 3.11 + uv
- Swap de 4GB